### PR TITLE
Add option for specifying Docker registry mirror

### DIFF
--- a/docker/ubuntu-14.04/Dockerfile
+++ b/docker/ubuntu-14.04/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:trusty
+# See below for why the MY_ prefix is used.
+ARG MY_REGISTRY
+FROM ${MY_REGISTRY}/ubuntu:trusty
 LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
 # USER and GROUP are reserved keywords in Dockerfile syntax, so put the goofy

--- a/docker/ubuntu-16.04/Dockerfile
+++ b/docker/ubuntu-16.04/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:xenial
+# See below for why the MY_ prefix is used.
+ARG MY_REGISTRY
+FROM ${MY_REGISTRY}/ubuntu:xenial
 LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
 # USER and GROUP are reserved keywords in Dockerfile syntax, so put the goofy

--- a/pyrex.ini
+++ b/pyrex.ini
@@ -43,6 +43,9 @@ tempdir = ${build:builddir}/pyrex
 # changed if that causes problems.
 %home = ${env:HOME}
 
+# The Docker registry from which to fetch the base image
+%registry = docker.io
+
 # The shell command to run for pyrex-shell
 %shell = /bin/bash
 

--- a/pyrex.py
+++ b/pyrex.py
@@ -169,6 +169,7 @@ def main():
             '--build-arg', 'MY_UID=%d' % os.getuid(),
             '--build-arg', 'MY_GID=%d' % os.getgid(),
             '--build-arg', 'MY_HOME=%s' % config['pyrex']['home'],
+            '--build-arg', 'MY_REGISTRY=%s' % config['pyrex']['registry'],
             '-t', config['pyrex']['tag'],
             '-f', config['pyrex']['dockerfile'],
             '--network=host',


### PR DESCRIPTION
This allows users whose networks have limited or no external Internet
connectivity to supply their own Docker registry for fetching base
images.

Signed-off-by: Matt Hoosier <matt.hoosier@garmin.com>