### PR TITLE
Don't run qemu in docker

### DIFF
--- a/pyrex.ini
+++ b/pyrex.ini
@@ -23,6 +23,12 @@ tempdir = ${build:builddir}/pyrex
 %    ${build:oeroot}/bitbake/bin/*
 %    ${build:oeroot}/scripts/*
 
+# A list of globs that should never be run in pyrex (e.g. not even using the
+# shim commands to setup the pyrex environment). These are simply added to
+# PATH by symlinks. Any commands listed here will take precedence over
+# ${commands}
+%commands_nopyrex =
+%   ${build:oeroot}/scripts/runqemu*
 
 # The docker executable to use
 %dockerpath = docker


### PR DESCRIPTION
Updates pyrex to avoid running the qemu scripts inside of the docker container. The container doesn't have sufficient privileges. The scripts to still end up executing -native qemu built in Yocto, but uninative helps make sure this will work sufficiently well outside of the container in which it was built.