### PR TITLE
Make sure timezone package is installed

### DIFF
--- a/docker/ubuntu-14.04/Dockerfile
+++ b/docker/ubuntu-14.04/Dockerfile
@@ -82,6 +82,9 @@ RUN apt-get -y update && apt-get -y install \
     g++-multilib \
 # Screen to enable devshell
     screen \
+# Base OS stuff that reasonable workstations have, but which the minimal
+# Docker registry image doesn't.
+    tzdata \
 && rm -rf /var/lib/apt/lists/*
 
 ENV PYREX_UTILS_VERSION=2019.02.22

--- a/docker/ubuntu-16.04/Dockerfile
+++ b/docker/ubuntu-16.04/Dockerfile
@@ -74,6 +74,9 @@ RUN apt-get -y update && apt-get -y install \
     g++-multilib \
 # Screen to enable devshell
     screen \
+# Base OS stuff that reasonable workstations have, but which the minimal
+# Docker registry image doesn't.
+    tzdata \
 && rm -rf /var/lib/apt/lists/*
 
 # Install wine, needed to test meta-mingw SDKs


### PR DESCRIPTION
Some recipes (e.g. meta-mono) happen to rely on having a
valid timezone configured. The 'tzdata' package isn't
explicitly itemized on the set of required packages [1],
but the timezone data package is implicitly installed on
any physical workstation copy of Ubuntu.

It's probably not realistic to try to wean application build
systems away from use of packages that are conventionally
always on Linux, whether or not these appear formally in Yocto's
requirements.

[1] https://www.yoctoproject.org/docs/2.2/mega-manual/mega-manual.html#detailed-supported-distros