### PR TITLE
docker: refactor dockerfile to create base images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.bak
 *.pyc
 
+# intermediate test files.
+/build/
+
 /poky/
 
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ install:
 - pip3 install coveralls
 - pip3 install requests
 before_script:
-- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 - printf '\nimport coverage\ncoverage.current_coverage = coverage.process_startup()\n'
   >> "/home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/lib/python${TRAVIS_PYTHON_VERSION}/sitecustomize.py"
 - rm -f .coverage-report.*
@@ -35,13 +34,13 @@ after_success:
 deploy:
 - provider: script
   skip_cleanup: true
-  script: "./ci/deploy_docker.py $TEST_IMAGE"
+  script: "./ci/deploy_docker.py --login $TEST_IMAGE"
   on:
     all_branches: true
     condition: "$TRAVIS_PULL_REQUEST == false && ($TRAVIS_BRANCH == master || $TRAVIS_TAG
       =~ ^v[0-9].*$)"
 - provider: script
   skip_cleanup: true
-  script: "./ci/deploy_docker.py $TEST_IMAGE:next"
+  script: "./ci/deploy_docker.py --login $TEST_IMAGE:next"
   on:
     branch: next

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ python:
 - '3.4'
 env:
   matrix:
-  - TEST_IMAGE=ubuntu-14.04
-  - TEST_IMAGE=ubuntu-16.04
-  - TEST_IMAGE=ubuntu-18.04
+  - TEST_IMAGE=ubuntu-14.04-base
+  - TEST_IMAGE=ubuntu-16.04-base
+  - TEST_IMAGE=ubuntu-18.04-base
+  - TEST_IMAGE=centos-7-base
+  - TEST_IMAGE=ubuntu-14.04-oe
+  - TEST_IMAGE=ubuntu-16.04-oe
+  - TEST_IMAGE=ubuntu-18.04-oe
   global:
     secure: rQjtyqgj25+q8f+WVl8kDaeaXhJStuWvxQCpAJs/GYhRbBVhNDjLzjcCx+VHadjKkPGNwO8ecgJZbA3jIFEsNXjXFmoDjX7ozuzas55WUVB80uHfxbzyVfoHjy75M4FPzGHQD9ljoYhmJ5UERnDmhvd0ttk3X8Jffv2EX0WvX/ekpvLr1AX+DXhP/1l80AsN00wdRFs8IA9Ajf3JZ2/tE+V3nMUJQqzJzdXZTksB4+mbzlNdk4mCj/LNJbQaEs8mTSamIfy48k6pY9LOwKgWIDykhbA0l0tr6/OjYT26lZvgXrH86D3r4/1PJXwU4KNFvyBXwyyRFayL5STDddcazyfnihIrXxj7qKJxatmhJYlZnO9iH0KFLEkWlaGi5QMnN7nxfUy7Leeo2yNiKsI8Z2l1RTVlFUw2mm5cz115p1m7gZsmJxhY3Ucd7vPS2yBwBUqOKgJWKOTly12srmYSvlO4dVRvauoP21seuhEgP3uaB4QZAZRDBlEwIvQ32NfKkHTjxqSFGA8gjqcH3StpvXF1O5QZzn/u5Xs2c6E9Tx2ro4wQhLJsxa3dSKqsVB6s6KIvaf+PMnrFV3vqnDL0CMp6pemTLmjLu7oJH7MQtrK8z++IRvS8HvAC4ChTPTqGxiIWiiUImtSbCnTsf3e+Y4uYXj2XG6G0Rz7ewcI/K3U=
 before_install:

--- a/ci/deploy_docker.py
+++ b/ci/deploy_docker.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import re
 import requests
 import subprocess
 import sys
@@ -64,9 +65,19 @@ def main():
         return 1
 
     print("Building", name)
+    # Construct the arguments for the build command.
+    docker_build_args = [
+        '-t', name,
+        '-f', '%s/Dockerfile' % docker_dir,
+        '--build-arg', 'PYREX_BASE=%s' % image,
+        '--target', 'pyrex-%s' % image.rsplit('-', 1)[-1]
+    ]
+
+    # Add the build context directory to our arguments.
+    docker_build_args.extend(['--', docker_dir])
+
     try:
-        subprocess.check_call(['docker', 'build', '-t', name, '-f', '%s/Dockerfile' % docker_dir,
-                               '--build-arg', 'PYREX_BASE=%s' % image, '--', docker_dir])
+        subprocess.check_call(['docker', 'build'] + docker_build_args)
     except subprocess.CalledProcessError as e:
         print("Building failed!")
         return 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PYREX_BASE=ubuntu-18.04
+ARG PYREX_BASE=ubuntu-18.04-oe
 ARG MY_REGISTRY=
 #
 # Base image for prebuilt static binaries
@@ -114,22 +114,105 @@ RUN mkdir -p /usr/src/tini && \
     make && \
     make install DESTDIR=/dist/tini && \
     mv /dist/tini/usr/local/bin/tini-static /dist/tini/usr/local/bin/tini
-
 #
 # Ubuntu 14.04 base
 #
-FROM ${MY_REGISTRY}ubuntu:trusty as ubuntu-14.04
+FROM ${MY_REGISTRY}ubuntu:trusty as ubuntu-14.04-base
 LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
-# Install software required to add ppa's
-RUN apt-get -y update && apt-get -y install \
-    python-software-properties \
-    software-properties-common
+# Install software required to run init scripts.
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
+    sudo \
+    locales \
+    lsb-release \
+    python \
+    python3 && \
+# Clean up apt-cache
+    rm -rf /var/lib/apt/lists/* &&\
+# generate utf8 locale
+    locale-gen en_US.UTF-8
 
+# Copy prebuilt items
+COPY --from=prebuilt-setpriv /dist/setpriv /
+COPY --from=prebuilt-tini /dist/tini /
+
+#
+# Ubuntu 16.04 Base
+
+FROM ${MY_REGISTRY}ubuntu:xenial as ubuntu-16.04-base
+LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
+
+# Install software required to run init scripts.
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
+    locales \
+    lsb-release \
+    sudo \
+    python \
+    python3 && \
+# Clean up apt-cache
+    rm -rf /var/lib/apt/lists/* &&\
+# generate utf8 locale
+    locale-gen en_US.UTF-8
+
+# Copy prebuilt items
+COPY --from=prebuilt-setpriv /dist/setpriv /
+COPY --from=prebuilt-tini /dist/tini /
+
+#
+# Ubuntu 18.04 Base
+#
+FROM ${MY_REGISTRY}ubuntu:bionic as ubuntu-18.04-base
+LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
+
+# Install software required to run init scripts.
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
+    python \
+    python3 \
+# Tools used by Pyrex
+    lsb-release \
+    setpriv \
+    sudo \
+    locales &&\
+    rm -rf /var/lib/apt/lists/* && \
+# generate utf8 locale
+    locale-gen en_US.UTF-8
+
+# Copy prebuilt items
+COPY --from=prebuilt-tini /dist/tini /
+
+#
+# Centos 7
+#
+FROM ${MY_REGISTRY}centos:7 as centos-7-base
+LABEL maintainer="James Harris <james.harris@garmin.com>"
+RUN set -x && \
+      #Install default components
+      yum install -y yum-utils \
+          which \
+          sudo \
+          redhat-lsb-core \
+          &&\
+      yum install -y https://centos7.iuscommunity.org/ius-release.rpm &&\
+      yum install -y python36u &&\
+      yum clean all &&\
+      ln -s /usr/bin/python3.6 /usr/bin/python3 &&\
+      localedef -c -f UTF-8 -i en_US en_US.UTF-8
+
+# Copy prebuilt items
+COPY --from=prebuilt-setpriv /dist/setpriv /
+COPY --from=prebuilt-tini /dist/tini /
+
+#
+# Ubuntu 14.04 Yocto Base
+#
+FROM ubuntu-14.04-base as ubuntu-14.04-oe
+LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
+
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
 # Add a non-ancient version of git
-RUN add-apt-repository -y ppa:git-core/ppa
-
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install software-properties-common && \
+    add-apt-repository -y ppa:git-core/ppa && \
+    apt-get -y update && apt-get -y install \
 # Poky 2.0 build dependencies
     gawk \
     wget \
@@ -178,9 +261,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y ins
     python-six \
     python3-six \
 # Useful tools for debugging Pyrex images
-    sudo \
     curl \
-    locales \
 # An updated version of Git (from the PPA source above)
 # that supports doing Yocto externalsrc recipes against free-
 # standing working copies that use Git worktrees.
@@ -197,24 +278,18 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y ins
 
 # Copy prebuilt items
 COPY --from=prebuilt-icecream /dist/icecream /
-COPY --from=prebuilt-setpriv /dist/setpriv /
-COPY --from=prebuilt-tini /dist/tini /
 
 #
-# Ubuntu 16.04 Base
+# Ubuntu 16.04 Yocto Base
 #
-FROM ${MY_REGISTRY}ubuntu:xenial as ubuntu-16.04
+FROM ubuntu-16.04-base as ubuntu-16.04-oe
 LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
-# Install software required to add ppa's
-RUN apt-get -y update && apt-get -y install \
-    python-software-properties \
-    software-properties-common
-
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
 # Add a non-ancient version of git
-RUN add-apt-repository -y ppa:git-core/ppa
-
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install software-properties-common && \
+    add-apt-repository -y ppa:git-core/ppa && \
+    apt-get -y update && apt-get -y install \
 # Poky 2.7 build dependencies
     gawk \
     wget \
@@ -255,9 +330,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y ins
     python-six \
     python3-six \
 # Useful tools for debugging Pyrex images
-    sudo \
     curl \
-    locales \
 # An updated version of Git (from the PPA source above)
 # that supports doing Yocto externalsrc recipes against free-
 # standing working copies that use Git worktrees.
@@ -277,16 +350,14 @@ RUN python3 -m pip install jinja2 iterfzf
 
 # Copy prebuilt items
 COPY --from=prebuilt-icecream /dist/icecream /
-COPY --from=prebuilt-setpriv /dist/setpriv /
-COPY --from=prebuilt-tini /dist/tini /
 
 #
 # Ubuntu 18.04 Base
 #
-FROM ${MY_REGISTRY}ubuntu:bionic as ubuntu-18.04
+FROM ubuntu-18.04-base as ubuntu-18.04-oe
 LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
+RUN set -x && export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y install \
 # Poky 2.7 build dependencies
     gawk \
     wget \
@@ -328,17 +399,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update && apt-get -y ins
     python-six \
     python3-six \
 # Useful tools for debugging Pyrex images
-    sudo \
     curl \
-    locales \
 # Corollary to the core Yocto gcc-multilib package. Allows various
 # prebuilt native tools to work
     g++-multilib \
 # Screen to enable devshell
     screen \
-# Tools used by Pyrex
-    lsb-release \
-    setpriv \
 # Base OS stuff that reasonable workstations have, but which the Docker
 # registry image doesn't
     tzdata \
@@ -349,29 +415,16 @@ RUN python3 -m pip install iterfzf
 
 # Copy prebuilt items
 COPY --from=prebuilt-icecream /dist/icecream /
-COPY --from=prebuilt-tini /dist/tini /
 
-# 
-# Target image
 #
-FROM ${PYREX_BASE}
+# Base image target.
+#
+# This stage sets up the minimal image startup and entry points. It also
+# ensures that the en_US.UTF-8 locale is installed and set correctly.
+#
+FROM ${PYREX_BASE} as pyrex-base
 
-# Setup Icecream distributed compiling client. The client tries several IPC
-# mechanisms to find the daemon, including connecting to a localhost TCP
-# socket. Since the local Icecream daemon (iceccd) is not started when the
-# docker container starts, the client will not find it and instead connect to
-# the host Icecream daemon (as long as the container is run with --net=host).
-RUN mkdir -p /usr/share/icecc/toolchain && \
-    cd /usr/share/icecc/toolchain/ && \
-    TC_NAME=$(mktemp) && \
-    /usr/local/libexec/icecc/icecc-create-env --gcc $(which gcc) $(which g++) 5> $TC_NAME && \
-    mv $(cat $TC_NAME) native-gcc.tar.gz && \
-    rm $TC_NAME
-
-ENV ICECC_VERSION=/usr/share/icecc/toolchain/native-gcc.tar.gz
-
-# Generate locales
-RUN locale-gen en_US.UTF-8
+# Set Locales
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
@@ -393,3 +446,27 @@ ENTRYPOINT ["/usr/local/bin/tini", "-P", "/usr/libexec/tini/cleanup.py", "{}", "
 # The startup script is expected to chain along to some other
 # command. By default, we'll use an interactive shell.
 CMD ["/bin/bash"]
+
+#
+# Yocto compatible target image.
+#
+# The final image is the yocto compatible target image. This image has the
+# Icecream destributed target setup correctly and install all of the desired
+# yocto dependencies.
+#
+FROM pyrex-base as pyrex-oe
+
+# Setup Icecream distributed compiling client. The client tries several IPC
+# mechanisms to find the daemon, including connecting to a localhost TCP
+# socket. Since the local Icecream daemon (iceccd) is not started when the
+# docker container starts, the client will not find it and instead connect to
+# the host Icecream daemon (as long as the container is run with --net=host).
+RUN mkdir -p /usr/share/icecc/toolchain && \
+    cd /usr/share/icecc/toolchain/ && \
+    TC_NAME=$(mktemp) && \
+    /usr/local/libexec/icecc/icecc-create-env --gcc $(which gcc) $(which g++) 5> $TC_NAME && \
+    mv $(cat $TC_NAME) native-gcc.tar.gz && \
+    rm $TC_NAME
+
+ENV ICECC_VERSION=/usr/share/icecc/toolchain/native-gcc.tar.gz
+

--- a/pyrex.ini
+++ b/pyrex.ini
@@ -35,7 +35,7 @@ tempdir = ${build:builddir}/pyrex
 
 # As a convenience, the name of a Pyrex provided Docker image
 # can be specified here
-%dockerimage = ubuntu-18.04
+%dockerimage = ubuntu-18.04-oe
 
 # As a convenience, the tag of the Pyrex provided image. Defaults to the
 # Pyrex version.

--- a/pyrex.py
+++ b/pyrex.py
@@ -277,7 +277,9 @@ def main():
                     '-t', tag,
                     '-f', config['dockerbuild']['dockerfile'],
                     '--network=host',
-                    os.path.join(config['build']['pyrexroot'], 'docker')
+                    os.path.join(config['build']['pyrexroot'], 'docker'),
+                    '--target', 'pyrex-%s' % config['config']['dockerimage'].rsplit('-', 1)[-1]
+
                     ]
 
                 if config['config']['registry']:


### PR DESCRIPTION
Other projects could take advantage of having a stripped down image that
supports the current user. It provides the following new images:

  * ubuntu-14.04-base
  * ubuntu-16.04-base
  * ubuntu-18.04-base
  * centos-7-base

It also renames the default images as follows:

  * ubuntu-14.04 -> ubuntu-14.04-oe
  * ubuntu-16.04 -> ubuntu-16.04-oe
  * ubuntu-18.04 -> ubuntu-18.04-oe

These images only install the bare minimum requirements to run tini and
eventually provide an updated version of git if such a version is
required upstream.

Centos does the additional work to install python3 (required by pyrex's
startup/shutdown scripts).

Integration instructions:

1. Update your pyrex.ini docker image to point to the newly reflected
   image names.