### PR TITLE
ci: Suppress stderr for quiet_init

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -138,7 +138,10 @@ class PyrexTest(object):
     def _write_host_command(self, args, quiet_init=False):
         cmd_file = os.path.join(self.thread_dir, 'command')
         with open(cmd_file, 'w') as f:
-            f.write('. ./poky/pyrex-init-build-env%s && ' % ('', ' > /dev/null')[quiet_init])
+            f.write('. ./poky/pyrex-init-build-env ')
+            if quiet_init:
+                f.write('> /dev/null 2>&1 ')
+            f.write('&& ')
             f.write(' && '.join(list(args)))
         return cmd_file
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
If quiet initialization is requested, suppress stderr also. It appears
that some versions of BuildKit output to stderr, which causes errors in
the test suite.