### PR TITLE
Add support for fixed config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,17 +116,35 @@ PYREX_ROOT="$(pwd)/meta-pyrex"
 # location that oe-init-build-env will look for local.conf.sample & friends)
 PYREXCONFTEMPLATE="$(pwd)/pyrex.ini.sample"
 
+# Alternatively, if it is desired to always use a fixed config file that users
+# can't change, set the following:
+#PYREXCONFFILE="$(pwd)/pyrex.ini"
+
 # Source the core pyrex environment script. Note that you must pass the
 # arguments
 . $(pwd)/meta-pyrex/pyrex-init-build-env "$@"
 ```
 
 ### Configuration
-Pyrex is configured using a `pyrex.ini` file located in the bitbake conf
-directory (i.e. the same place as `local.conf`). Pyrex will generate a default
-`pyrex.ini` file if one doesn't exist by either copying a `pyrex.ini.sample`
-file from the [TEMPLATECONF][] directory, or if one doesn't exist creating it
-from the internal Pyrex default configuration.
+Pyrex is configured using a ini-style configuration file and uses the following
+precedence to determine where this file is located:
+1. The file specified in the environment variable `PYREXCONFFILE`.
+2. The `pyrex.ini` file in the bitbake conf directory (e.g.
+   `${OEROOT}/build/conf/pyrex.ini`, if it exists and has a version number
+   specified in `${config:confversion}`. For further rules, this file will
+   be known as `PYREX_USER_CONF`
+3. If the file specified in the environment variable `$PYREXCONFTEMPLATE` exists,
+   is copied to `PYREX_USER_CONF`, then `PYREX_USER_CONF` is used
+4. If the file `$TEMPLATECONF/pyrex.ini.sample` exists, it is copied to
+   `PYREX_USER_CONF`, the `PYREX_USER_CONF` is used. This is the same rules
+   that bitbake uses for `local.conf.sample`, allowing you to easily put a
+   `pyrex.conf.sample` file along side the other default config files. See
+   [TEMPLATECONF][].
+5. The internal default config file provided by Pyrex is coped to
+   `PYREX_USER_CONF`, then `PYREX_USER_CONF` is used.
+
+**Note:** The config file is only populated when Pyrex initializes the
+environment (e.g. when the init script is sourced).
 
 The configuration file is the ini file format supported by Python's
 [configparser](https://docs.python.org/3/library/configparser.html) class, with

--- a/ci/test.py
+++ b/ci/test.py
@@ -397,6 +397,30 @@ class PyrexImageType_base(PyrexTest):
 
         self.assertPyrexHostCommand('true', returncode=1, env=env)
 
+    def test_force_conf(self):
+        # Write out a new config file and set the variable to force it to be
+        # used
+        conf = self.get_config()
+        conf['config']['test'] = 'bar'
+        force_conf_file = os.path.join(self.thread_dir, 'force.ini')
+        with open(force_conf_file, 'w') as f:
+            conf.write(f)
+
+        # Set the variable to a different value in the standard config file
+        conf = self.get_config()
+        conf['config']['test'] = 'foo'
+        conf.write_conf()
+
+        output = self.assertPyrexHostCommand('pyrex-config get config:test', quiet_init=True,
+                                             capture=True).decode('utf-8').strip()
+        self.assertEqual(output, 'foo')
+
+        env = os.environ.copy()
+        env['PYREXCONFFILE'] = force_conf_file
+        output = self.assertPyrexHostCommand('pyrex-config get config:test', quiet_init=True,
+                                             capture=True, env=env).decode('utf-8').strip()
+        self.assertEqual(output, 'bar')
+
     @skipIfPrebuilt
     def test_local_build(self):
         # Run any command to build the images locally

--- a/pyrex-init-build-env
+++ b/pyrex-init-build-env
@@ -46,7 +46,7 @@ fi
 
 pyrex_cleanup() {
 	rm -f "$PYREX_TEMP_FILE"
-	unset PYREX_OEROOT PYREX_OEINIT PYREX_ROOT PYREX_CONFFILE PYREX_TEMP_FILE pyrex_cleanup
+	unset PYREX_OEROOT PYREX_OEINIT PYREX_ROOT PYREX_TEMPCONFFILE PYREX_TEMP_FILE pyrex_cleanup
 }
 
 # Capture OE Build environment
@@ -74,17 +74,17 @@ if [ $? -ne 0 ]; then
 	pyrex_cleanup
 	return 1
 fi
-PYREX_CONFFILE=$(cat $PYREX_TEMP_FILE)
+PYREX_TEMPCONFFILE=$(cat $PYREX_TEMP_FILE)
 
 # Build Pyrex images
-$PYREX_ROOT/pyrex.py build "$PYREX_CONFFILE"
+$PYREX_ROOT/pyrex.py build "$PYREX_TEMPCONFFILE"
 if [ $? -ne 0 ]; then
 	pyrex_cleanup
 	return 1
 fi
 
 # Setup build environment
-$PYREX_ROOT/pyrex.py env "$PYREX_CONFFILE" 11 11> $PYREX_TEMP_FILE
+$PYREX_ROOT/pyrex.py env "$PYREX_TEMPCONFFILE" 11 11> $PYREX_TEMP_FILE
 if [ $? -ne 0 ]; then
 	pyrex_cleanup
 	return 1

--- a/pyrex.py
+++ b/pyrex.py
@@ -522,8 +522,13 @@ def main():
         write_cmd('cd "%s"' % config['build']['builddir'])
         return 0
 
+    subparser_args = {}
+    if sys.version_info >= (3, 6, 0):
+        subparser_args['required'] = True
+
     parser = argparse.ArgumentParser(description='Pyrex Setup Argument Parser')
-    subparsers = parser.add_subparsers(title='subcommands', description='Setup subcommands')
+    subparsers = parser.add_subparsers(title='subcommands', description='Setup subcommands', dest='subcommand',
+                                       **subparser_args)
 
     capture_parser = subparsers.add_parser('capture', help='Capture OE init environment')
     capture_parser.add_argument('fd', help='Output file descriptor', type=int)


### PR DESCRIPTION
Adds support for specifying a "fixed" config file for Pyrex (that is,
one that always overwrites anything the user might have in their local
pyrex.ini file). This file is specified by setting the PYREXCONFFILE
environment variable.