### PR TITLE
Comply with flake8 linter

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,3 @@
+scanner:
+  diff_only: True
+  linter: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,14 @@ install:
 - pip3 install coverage
 - pip3 install coveralls
 - pip3 install requests
+- pip3 install flake8
 before_script:
 - printf '\nimport coverage\ncoverage.current_coverage = coverage.process_startup()\n'
   >> "/home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/lib/python${TRAVIS_PYTHON_VERSION}/sitecustomize.py"
 - rm -f .coverage-report.*
-script: COVERAGE_PROCESS_START=${TRAVIS_BUILD_DIR}/.coveragerc ci/test.py -vb PyrexImage_$(echo $TEST_IMAGE | sed 's/\W/_/g')
+script:
+- flake8 $(git ls-files '*.py')
+- COVERAGE_PROCESS_START=${TRAVIS_BUILD_DIR}/.coveragerc ci/test.py -vb PyrexImage_$(echo $TEST_IMAGE | sed 's/\W/_/g')
 after_success:
 - coverage3 combine
 - coveralls

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,23 @@
 # Developer Guide
 Pyrex development information and processes
 
+## Linting
+Pyrex conforms to [PEP8](https://pep8.org/) for all Python code, and also make
+use of [flake8](https://pypi.org/project/flake8/) as a linter. Please ensure
+all code conforms to this. There is helpful tool that will report any places
+where the code is non-conformant in the project root:
+
+```shell
+./lint
+```
+
+If you would like to tool to automatically reformat code to comply with PEP8,
+pass the `--reformat` option:
+
+```
+./lint --reformat
+```
+
 ## Testing
 Pyrex has a comprehensive test suite that can be used to test all generated
 Docker images. Some external test data is required to perform the test. To

--- a/docker/cleanup.py
+++ b/docker/cleanup.py
@@ -25,10 +25,10 @@ import time
 # These Linux process states are considered "already dead" and will not cause
 # the script to wait
 ALREADY_DEAD_STATES = (
-        'Z', # Zombie
-        'X', # Dead (from Linux 2.6.0 onward)
-        'x', # Dead (Linux 2.6.33 to 3.13 only)
-        )
+    'Z',  # Zombie
+    'X',  # Dead (from Linux 2.6.0 onward)
+    'x',  # Dead (Linux 2.6.33 to 3.13 only)
+)
 
 EXIT_WAIT_PHASES = 2
 
@@ -69,20 +69,24 @@ INTERRUPT_SIGNALS = (
     signal.SIGINT,
     signal.SIGQUIT,
     signal.SIGTERM,
-    )
+)
+
 
 def pid_str_list(s):
     return '  ' + '\n  '.join(s[key] for key in sorted(s.keys()))
+
 
 signals_enabled = False
 keep_waiting = True
 keep_waiting_notified = False
 
+
 def stop_process_waiting(signum, frame):
     global keep_waiting
     keep_waiting = False
     # Note: Can't use logging in a signal handler. Uncomment this to debug
-    #print("Got signal %d" % signum)
+    #print("Got signal %d" % signum) # NOQA
+
 
 def wait_for_processes(sig, max_wait):
     global keep_waiting
@@ -132,8 +136,8 @@ def wait_for_processes(sig, max_wait):
 
                 logging.debug("Found %s", description)
 
-                if not state in ALREADY_DEAD_STATES and pid != my_pid and pid != 1:
-                    if not pid in killed_processes and sig is not None:
+                if state not in ALREADY_DEAD_STATES and pid != my_pid and pid != 1:
+                    if pid not in killed_processes and sig is not None:
                         logging.info("Killing %s", description)
                         os.kill(pid, sig)
                         killed_processes.add(pid)
@@ -176,6 +180,7 @@ def wait_for_processes(sig, max_wait):
             sleep_time = 0.5
 
         time.sleep(sleep_time)
+
 
 def main():
     # Setup logging. The child stdout may need to be parsable, so the logging
@@ -226,6 +231,7 @@ def main():
 
     # Pass the previous child exit code on to tini
     return int(sys.argv[1])
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/docker/entry.py
+++ b/docker/entry.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 import os
-import stat
 import sys
 import subprocess
 import signal
+
 
 def get_var(name):
     if name in os.environ:
@@ -31,6 +31,7 @@ def get_var(name):
     sys.stderr.write('"%s" is missing from the environment\n' % name)
     sys.exit(1)
 
+
 def main():
     # Block the SIGTSTP signal. We haven't figured out how to do proper job
     # control inside of docker yet, and if the user accidentally presses CTRL+Z
@@ -41,9 +42,12 @@ def main():
 
     # Check TERM
     if 'TERM' in os.environ:
-        r = subprocess.call(['/usr/bin/infocmp', os.environ['TERM']], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+        r = subprocess.call(['/usr/bin/infocmp', os.environ['TERM']],
+                            stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
         if r != 0:
-            sys.stderr.write('$TERM has an unrecognized value of "%s". The interactive terminal may not behave appropriately\n' % os.environ['TERM'])
+            sys.stderr.write(
+                '$TERM has an unrecognized value of "%s". The interactive terminal may not behave appropriately\n' %
+                os.environ['TERM'])
 
     uid = int(get_var('PYREX_UID'))
     gid = int(get_var('PYREX_GID'))
@@ -58,20 +62,20 @@ def main():
 
         # Create user and group
         subprocess.check_call(['groupadd',
-                '--non-unique',
-                '--gid', '%d' % gid,
-                group
-            ], stdout=subprocess.DEVNULL)
+                               '--non-unique',
+                               '--gid', '%d' % gid,
+                               group
+                               ], stdout=subprocess.DEVNULL)
 
         subprocess.check_call(['useradd',
-                '--non-unique',
-                '--uid', '%d' % uid,
-                '--gid', '%d' % gid,
-                '--home', home,
-                '--no-create-home',
-                '--shell', '/bin/sh',
-                user
-            ], stdout=subprocess.DEVNULL)
+                               '--non-unique',
+                               '--uid', '%d' % uid,
+                               '--gid', '%d' % gid,
+                               '--home', home,
+                               '--no-create-home',
+                               '--shell', '/bin/sh',
+                               user
+                               ], stdout=subprocess.DEVNULL)
 
         try:
             os.makedirs(home, 0o755)
@@ -115,17 +119,17 @@ def main():
 
     # Invoke setpriv to drop root privileges.
     os.execlp('setpriv', 'setpriv',
-        '--inh-caps=-all', # Drop all root capabilities
-        '--clear-groups',
-        '--reuid', '%d' % uid,
-        '--regid', '%d' % gid,
-        *sys.argv[1:]
-        )
+              '--inh-caps=-all',  # Drop all root capabilities
+              '--clear-groups',
+              '--reuid', '%d' % uid,
+              '--regid', '%d' % gid,
+              *sys.argv[1:]
+              )
 
     # If we get here, it is an error
     sys.syderr.write('Unable to exec setpriv\n')
     sys.exit(1)
 
+
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/lint
+++ b/lint
@@ -1,0 +1,33 @@
+#! /bin/sh
+#
+# Copyright 2019 Garmin Ltd. or its subsidiaries
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if ! which autopep8 > /dev/null 2>&1; then
+    echo "autopep8 not found!"
+    exit 1
+fi
+
+if ! which flake8 > /dev/null 2>&1; then
+    echo "flake8 not found!"
+    exit 1
+fi
+
+cd "$(readlink -f $(dirname $0))"
+if [ "$1" == "-r" ] || [ "$1" == "--reformat" ]; then
+    autopep8 -i -a --global-config /dev/null $(git ls-files '*.py')
+fi
+
+flake8 $(git ls-files '*.py')
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pycodestyle]
+[flake8]
 max-line-length = 120


### PR DESCRIPTION
Reformats Python code according to pep8, and fixes up flake8 warnings.

Adds a lint script that can be run to fix up the code to be conformant
in the future.

Updates the Travis CI tests to run flake8 as part of the automated tests