### PR TITLE
Add support for custom startup executables

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -561,6 +561,21 @@ class PyrexImageType_base(PyrexTest):
             'echo $TEST_ENV2', env=env, quiet_init=True, capture=True).decode('utf-8').rstrip()
         self.assertEqual(s, '')
 
+    def test_custom_startup_script(self):
+        conf = self.get_config()
+        conf['run']['envvars'] += ' PYREX_TEST_STARTUP_SCRIPT'
+        conf.write_conf()
+
+        env = os.environ.copy()
+        env['PYREX_TEST_STARTUP_SCRIPT'] = "3"
+        self.assertPyrexContainerShellCommand(
+            'echo $PYREX_TEST_STARTUP_SCRIPT', env=env, quiet_init=True, returncode=3)
+
+        env['PYREX_TEST_STARTUP_SCRIPT'] = "0"
+        s = self.assertPyrexContainerShellCommand(
+            'echo $PYREX_TEST_STARTUP_SCRIPT', env=env, quiet_init=True, capture=True).decode('utf-8').rstrip()
+        self.assertEqual(s, "Startup script test\n0")
+
 
 class PyrexImageType_oe(PyrexImageType_base):
     """

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -441,6 +441,9 @@ RUN chmod +x /usr/libexec/tini/cleanup.py \
     /usr/libexec/tini/entry.py \
     /usr/libexec/tini/startup.sh
 
+# Add startup script directory.
+RUN mkdir -p /usr/libexec/pyrex/startup.d
+
 # Precompile python files for improved startup time
 RUN python3 -m py_compile /usr/libexec/tini/*.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -441,8 +441,8 @@ RUN chmod +x /usr/libexec/tini/cleanup.py \
     /usr/libexec/tini/entry.py \
     /usr/libexec/tini/startup.sh
 
-# Add startup script directory.
-RUN mkdir -p /usr/libexec/pyrex/startup.d
+# Add startup script directory & test script.
+COPY ./test_startup.sh /usr/libexec/pyrex/startup.d/
 
 # Precompile python files for improved startup time
 RUN python3 -m py_compile /usr/libexec/tini/*.py

--- a/docker/entry.py
+++ b/docker/entry.py
@@ -117,6 +117,16 @@ def main():
     except OSError:
         pass
 
+    # Execute any startup executables.
+    for exe in os.listdir('/usr/libexec/pyrex/startup.d'):
+        path = os.path.join('/usr/libexec/pyrex/startup.d', exe)
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            try:
+                subprocess.check_call([path])
+            except subprocess.CalledProcessError as e:
+                sys.stderr.write('%s exited with %d\n' % (path, e.returncode))
+                sys.exit(e.returncode)
+
     # Invoke setpriv to drop root privileges.
     os.execlp('setpriv', 'setpriv',
               '--inh-caps=-all',  # Drop all root capabilities

--- a/docker/test_startup.sh
+++ b/docker/test_startup.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+if [ -z "${PYREX_TEST_STARTUP_SCRIPT+isset}" ]; then
+    exit 0
+fi
+
+echo "Startup script test"
+exit $PYREX_TEST_STARTUP_SCRIPT


### PR DESCRIPTION
Add hooks for including custom startup executables in
'/usr/libexec/pyrex/startup.d/'.