### PR TITLE
Use fd 9, not fd 11, to improve shell portability

### DIFF
--- a/pyrex-init-build-env
+++ b/pyrex-init-build-env
@@ -67,8 +67,8 @@ pyrex_cleanup() {
 	export PYREX_OEROOT PYREX_OEINIT PYREX_ROOT PYREXCONFTEMPLATE
 
 	# Instruct pyrex.py to output the name of the configuration file to
-	# file descriptor 11
-	$PYREX_ROOT/pyrex.py capture 11 -- "$@" 11> $PYREX_TEMP_FILE
+	# file descriptor 9
+	$PYREX_ROOT/pyrex.py capture 9 -- "$@" 9> $PYREX_TEMP_FILE
 )
 if [ $? -ne 0 ]; then
 	pyrex_cleanup
@@ -84,7 +84,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Setup build environment
-$PYREX_ROOT/pyrex.py env "$PYREX_TEMPCONFFILE" 11 11> $PYREX_TEMP_FILE
+$PYREX_ROOT/pyrex.py env "$PYREX_TEMPCONFFILE" 9 9> $PYREX_TEMP_FILE
 if [ $? -ne 0 ]; then
 	pyrex_cleanup
 	return 1


### PR DESCRIPTION
On zsh, pyrex currently fails due to the usage of fd 11. It seems that
use of fds greater than 9 are implementation defined, and therefore not
portable, running into issues with ksh or zsh. See section 2.7, Shell
Command Language, POSIX.1-2017:

> Open files are represented by decimal numbers starting with zero.
> The largest possible value is implementation-defined; however, all
> implementations shall support at least 0 to 9, inclusive, for use by
> the application.

Close #31