### PR TITLE
Capture and use the dir where the init command is sourced

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -19,8 +19,8 @@ declare -a COMMAND=("$@")
 # Consume all arguments before sourcing the environment script
 shift $#
 
-if [ -n "$PYREX_OEROOT" ] && [ -n "$PYREX_INIT_COMMAND" ]; then
-    pushd "$PYREX_OEROOT" > /dev/null
+if [ -n "$PYREX_INIT_DIR" ] && [ -n "$PYREX_INIT_COMMAND" ]; then
+    pushd "$PYREX_INIT_DIR" > /dev/null
     source $PYREX_INIT_COMMAND > /dev/null
     popd > /dev/null
 fi

--- a/pyrex-init-build-env
+++ b/pyrex-init-build-env
@@ -46,11 +46,13 @@ fi
 
 pyrex_cleanup() {
 	rm -f "$PYREX_TEMP_FILE"
-	unset PYREX_OEROOT PYREX_OEINIT PYREX_ROOT PYREX_TEMPCONFFILE PYREX_TEMP_FILE pyrex_cleanup
+	unset PYREX_OEROOT PYREX_OEINIT PYREX_OEINIT_DIR PYREX_ROOT PYREX_TEMPCONFFILE PYREX_TEMP_FILE pyrex_cleanup
 }
 
 # Capture OE Build environment
 (
+	PYREX_OEINIT_DIR="$PWD"
+
 	. $PYREX_OEINIT "$@"
 	if [ $? -ne 0 ]; then
 		exit 1
@@ -64,7 +66,7 @@ pyrex_cleanup() {
 		esac
 	fi
 
-	export PYREX_OEROOT PYREX_OEINIT PYREX_ROOT PYREXCONFTEMPLATE
+	export PYREX_OEROOT PYREX_OEINIT PYREX_OEINIT_DIR PYREX_ROOT PYREXCONFTEMPLATE
 
 	# Instruct pyrex.py to output the name of the configuration file to
 	# file descriptor 11

--- a/pyrex.py
+++ b/pyrex.py
@@ -213,6 +213,7 @@ def main():
         build_config['build']['oeinit'] = oeinit
         build_config['build']['pyrexroot'] = os.environ['PYREX_ROOT']
         build_config['build']['initcommand'] = ' '.join(shlex.quote(a) for a in [oeinit] + args.init)
+        build_config['build']['initdir'] = os.environ['PYREX_OEINIT_DIR']
         build_config['build']['userconfig'] = conffile
 
         # Merge the build config into the user config (so that interpolation works)
@@ -464,6 +465,7 @@ def main():
             username = config['run'].get('username') or pwd.getpwuid(uid).pw_name
             groupname = config['run'].get('groupname') or grp.getgrgid(gid).gr_name
             init_command = config['run'].get('initcommand', config['build']['initcommand'])
+            init_dir = config['run'].get('initdir', config['build']['initdir'])
 
             command_prefix = config['run'].get('commandprefix', '').splitlines()
 
@@ -477,7 +479,7 @@ def main():
                            '-e', 'PYREX_GID=%d' % gid,
                            '-e', 'PYREX_HOME=%s' % os.environ['HOME'],
                            '-e', 'PYREX_INIT_COMMAND=%s' % init_command,
-                           '-e', 'PYREX_OEROOT=%s' % config['build']['oeroot'],
+                           '-e', 'PYREX_INIT_DIR=%s' % init_dir,
                            '-e', 'PYREX_CLEANUP_EXIT_WAIT',
                            '-e', 'PYREX_CLEANUP_LOG_FILE',
                            '-e', 'PYREX_CLEANUP_LOG_LEVEL',
@@ -529,7 +531,7 @@ def main():
 
             env = os.environ.copy()
             env['PYREX_INIT_COMMAND'] = config['build']['initcommand']
-            env['PYREX_OEROOT'] = config['build']['oeroot']
+            env['PYREX_INIT_DIR'] = config['build']['initdir']
 
             stop_coverage()
 


### PR DESCRIPTION
This fixes issues with relative build dir paths by ensuring we source
the init command from the same place both outside of docker and inside
of docker.

Close #32