### PR TITLE
Remove all non-root users and groups

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -576,6 +576,22 @@ class PyrexImageType_base(PyrexTest):
             'echo $PYREX_TEST_STARTUP_SCRIPT', env=env, quiet_init=True, capture=True).decode('utf-8').rstrip()
         self.assertEqual(s, "Startup script test\n0")
 
+    def test_users(self):
+        users = set(
+            self.assertPyrexContainerShellCommand(
+                'getent passwd | cut -f1 -d:',
+                quiet_init=True,
+                capture=True).decode('utf-8').rstrip().split())
+        self.assertEqual(users, {'root', pwd.getpwuid(os.getuid()).pw_name})
+
+    def test_groups(self):
+        groups = set(
+            self.assertPyrexContainerShellCommand(
+                'getent group | cut -f1 -d:',
+                quiet_init=True,
+                capture=True).decode('utf-8').rstrip().split())
+        self.assertEqual(groups, {'root', grp.getgrgid(os.getgid()).gr_name})
+
 
 class PyrexImageType_oe(PyrexImageType_base):
     """

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -203,6 +203,9 @@ RUN set -x && \
       yum clean all &&\
       localedef -c -f UTF-8 -i en_US en_US.UTF-8
 
+# Reset the default useradd options for when the primary user is added
+RUN echo "SHELL=/bin/bash" > /etc/default/useradd
+
 # Copy prebuilt items
 COPY --from=prebuilt-setpriv /dist/setpriv /
 COPY --from=prebuilt-tini /dist/tini /
@@ -446,6 +449,11 @@ COPY ./test_startup.sh /usr/libexec/pyrex/startup.d/
 
 # Precompile python files for improved startup time
 RUN python3 -m py_compile /usr/libexec/tini/*.py
+
+# Remove all non-root users and groups so that there are no conflicts when the
+# user is added
+RUN getent passwd | cut -f1 -d: | grep -v '^root$' | xargs -L 1 userdel
+RUN getent group | cut -f1 -d: | grep -v '^root$' | xargs -L 1 groupdel
 
 # Use tini as the init process and instruct it to invoke the cleanup script
 # once the primary command dies


### PR DESCRIPTION
Remove all non-root users and groups from the container images. This
ensures that when the user is added there is no conflict.

Fixes #37