### PR TITLE
Add 'optional' argument in bind-mount config

### DIFF
--- a/pyrex.ini
+++ b/pyrex.ini
@@ -82,6 +82,13 @@ confversion = @CONFVERSION@
 %enable = 1
 
 # A list of directories that should be bound when running in the container
+#
+# Paths specified here may optionally be followed by a comma-separated
+# list of options. E.g. "bind = dir[,option1,option2,...]
+#
+# The only currently supported option is 'optional', which
+# indicates that Pyrex should silently ignore a directory name which doesn't
+# exist.
 %bind =
 %   ${env:PYREX_BIND}
 

--- a/pyrex.py
+++ b/pyrex.py
@@ -470,8 +470,18 @@ def prep_container(
         + extra_bind
     )
     for b in set(binds):
+        # Separate out into the directory itself and trailing options.
+        options = b.split(',')[1:]
+        b = b.split(',')[0]
+        optional = False
+        for o in options:
+            if o == 'optional':
+                optional = True
+            else:
+                print("Warning: unrecognized option {o} in bind source path b".format(o=o, b=b))
         if not os.path.exists(b):
-            print("Error: bind source path {b} does not exist".format(b=b))
+            if not optional:
+                print("Warning: bind source path {b} does not exist".format(b=b))
             continue
         engine_args.extend(["--mount", "type=bind,src={b},dst={b}".format(b=b)])
 


### PR DESCRIPTION
Allow directories specified in the [run:bind] config to be specified
as optional.

This allows a more graceful error-reporting behavior when canned
corporate configurations want to bind in various directories that
carry credentials for fetchers (SSH, wget, etc).