### PR TITLE
image: guard against userdel/groupdel failing on 0 input arguments

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -540,8 +540,8 @@ RUN python3 -m py_compile /usr/libexec/pyrex/*.py
 
 # Remove all non-root users and groups so that there are no conflicts when the
 # user is added
-RUN getent passwd | cut -f1 -d: | grep -v '^root$' | xargs -L 1 userdel
-RUN getent group | cut -f1 -d: | grep -v '^root$' | xargs -L 1 groupdel
+RUN getent passwd | cut -f1 -d: | grep -v '^root$' | xargs -r -L 1 userdel
+RUN getent group | cut -f1 -d: | grep -v '^root$' | xargs -r -L 1 groupdel
 
 # Use tini as the init process and instruct it to invoke the cleanup script
 # once the primary command dies


### PR DESCRIPTION
Depending on the details of what auxiliary groups or user accounts get
made during package installation, it can happen that there are no
non-root accounts or no non-root groups.

This trips up the logic that destroys all of those to present a clean
slate to the user account creation logic done by the entrypoint.

Rephrase the cleanup operation as a loop rather than an xargs to avoid
this.

Signed-off-by: Matt Hoosier <matt.hoosier@garmin.com>