### PR TITLE
Fix PYREX_BIND not actually binding

### DIFF
--- a/pyrex.ini
+++ b/pyrex.ini
@@ -54,7 +54,9 @@ confversion = @CONFVERSION@
 # and populating it with the default values. Also note that Pyrex will attempt
 # to perform variable expansion on the environment variable values, so care
 # should be taken
-%envimport = HOME
+%envimport =
+%    HOME
+%    PYREX_BIND
 
 [imagebuild]
 # The command used to build container images


### PR DESCRIPTION
The PYREX_BIND environment variable wasn't working as advertised by
default because it was in the set of imported environment variables.
Correct this and add a test to verify it works.