### PR TITLE
Fix using terminal when $TERM is not set

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -292,7 +292,7 @@ class PyrexTest(object):
         self.assertEqual(
             os.WEXITSTATUS(status), returncode, msg="%s failed" % " ".join(args)
         )
-        return b"".join(stdout)
+        return (b"".join(stdout)).decode("utf-8").rstrip()
 
 
 class PyrexImageType_base(PyrexTest):
@@ -596,9 +596,7 @@ class PyrexImageType_base(PyrexTest):
         bad_term = "this-is-not-a-valid-term"
         env = os.environ.copy()
         env["TERM"] = bad_term
-        output = (
-            self.assertPyrexContainerShellPTY("true", env=env).decode("utf-8").strip()
-        )
+        output = self.assertPyrexContainerShellPTY("true", env=env)
         self.assertIn('$TERM has an unrecognized value of "%s"' % bad_term, output)
         self.assertPyrexContainerShellPTY(
             "/usr/bin/infocmp %s > /dev/null" % bad_term,
@@ -615,21 +613,13 @@ class PyrexImageType_base(PyrexTest):
         for t in REQUIRED_TERMS:
             with self.subTest(term=t):
                 env["TERM"] = t
-                output = (
-                    self.assertPyrexContainerShellPTY(
-                        "echo $TERM", env=env, quiet_init=True
-                    )
-                    .decode("utf-8")
-                    .strip()
+                output = self.assertPyrexContainerShellPTY(
+                    "echo $TERM", env=env, quiet_init=True
                 )
                 self.assertEqual(output, t, msg="Bad $TERM found in container!")
 
-                output = (
-                    self.assertPyrexContainerShellPTY(
-                        "/usr/bin/infocmp %s > /dev/null" % t, env=env
-                    )
-                    .decode("utf-8")
-                    .strip()
+                output = self.assertPyrexContainerShellPTY(
+                    "/usr/bin/infocmp %s > /dev/null" % t, env=env
                 )
                 self.assertNotIn("$TERM has an unrecognized value", output)
 

--- a/pyrex.py
+++ b/pyrex.py
@@ -509,7 +509,7 @@ def prep_container(
         )
 
     # Run the container with a TTY if this script was run in a tty
-    if os.isatty(1):
+    if os.isatty(1) and "TERM" in os.environ and os.environ["TERM"]:
         engine_args.append("-t")
 
     # Configure binds


### PR DESCRIPTION
Changes Pyrex to no longer pass -t if $TERM is not set (or is empty) in
the environment, and adds tests to ensure the happens correctly.

This fixes commands in the container issuing errors like:

    tput: No value for $TERM and no -T specified