### PR TITLE
Rework user commands to add to container commands

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -656,6 +656,44 @@ class PyrexImageType_base(PyrexTest):
                 )
                 self.assertEqual(output, t, msg="Bad $TERM found in container!")
 
+    def test_term_enabled(self):
+        env = os.environ.copy()
+        env["TERM"] = "dumb"
+        output = self.assertPyrexContainerShellPTY(
+            "test -t 1; echo $?",
+            env=env,
+            quiet_init=True,
+        )
+        self.assertEqual(output, "0", msg="Stdout is not a TTY")
+
+        del env["TERM"]
+        output = self.assertPyrexContainerShellPTY(
+            "test -t 1; echo $?",
+            env=env,
+            quiet_init=True,
+        )
+        self.assertEqual(output, "0", msg="Stdout is not a TTY")
+
+    def test_term_disabled(self):
+        env = os.environ.copy()
+        env["TERM"] = "dumb"
+        output = self.assertPyrexContainerShellCommand(
+            "test -t 1; echo $?",
+            env=env,
+            quiet_init=True,
+            capture=True,
+        )
+        self.assertEqual(output, "1", msg="Stdout is a TTY when terminal is not a TTY")
+
+        del env["TERM"]
+        output = self.assertPyrexContainerShellCommand(
+            "test -t 1; echo $?",
+            env=env,
+            quiet_init=True,
+            capture=True,
+        )
+        self.assertEqual(output, "1", msg="Stdout is a TTY when terminal is not a TTY")
+
     def test_tini(self):
         self.assertPyrexContainerCommand("tini --version")
 

--- a/pyrex.ini
+++ b/pyrex.ini
@@ -31,7 +31,7 @@ confversion = @CONFVERSION@
 
 # As a convenience, the name of a Pyrex provided image
 # can be specified here
-%image = ubuntu-18.04-${config:imagetype}
+%image = ubuntu-20.04-${config:imagetype}
 
 # As a convenience, the tag of the Pyrex provided image. Defaults to the
 # Pyrex version.


### PR DESCRIPTION
Reworks the way that commands specified by the user are wrapped by
Pyrex. Instead of completely replacing the container commands, the user
commands override and extend the container command defintions, taking
precedence over them (i.e. if the user excludes a command it will be
excluded even if the container includes it, and if the user includes it,
it will be included even if the container excludes it).

In order for this to work, the user command shims must be individually
written to execute the full path to the command inside the container,
since we don't know if it will be in $PATH.

