### PR TITLE
Fix Ubuntu 20.04 builds

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -587,7 +587,9 @@ ENV PYREX_BASE none
 
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     sudo dpkg --add-architecture i386 && \
-    apt-get -y update && apt-get -y install \
+    apt -y update && \
+    apt -y upgrade apt && \
+    apt -y install \
         wine64 \
         wine32 \
 && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Update apt manually as a work around for
https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1871268.