### PR TITLE
Move user/group sanitization into image entry

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -630,11 +630,6 @@ COPY ./test_startup.sh /usr/libexec/pyrex/startup.d/
 # Precompile python files for improved startup time
 RUN python3 -m py_compile /usr/libexec/pyrex/*.py
 
-# Remove all non-root users and groups so that there are no conflicts when the
-# user is added
-RUN getent passwd | cut -f1 -d: | grep -v '^root$' | xargs -r -L 1 userdel
-RUN getent group | cut -f1 -d: | grep -v '^root$' | xargs -r -L 1 groupdel
-
 # Use tini as the init process and instruct it to invoke the cleanup script
 # once the primary command dies
 ENTRYPOINT ["/usr/local/bin/tini", "-P", "/usr/libexec/pyrex/cleanup.py", "{}", ";", "--", "/usr/libexec/pyrex/entry.py"]

--- a/image/entry.py
+++ b/image/entry.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import grp
 import os
+import pwd
 import sys
 import subprocess
 import signal
@@ -68,6 +70,29 @@ def main():
     if not os.path.exists(check_file):
         with open(check_file, "w") as f:
             f.write("%d %d %s %s\n" % (uid, primarygid, user, primarygroup))
+
+            # Remove all non-root users and groups so that there are no conflicts
+            # when the user is added.
+            for p in pwd.getpwall():
+
+                if p[2] == 0:
+                    continue
+
+                subprocess.check_call(
+                    [
+                        "userdel",
+                        p[0],
+                    ],
+                )
+
+            for g in grp.getgrall():
+
+                if g[2] == 0:
+                    continue
+
+                subprocess.check_call(
+                    ["groupdel", g[0]],
+                )
 
             # Create user and groups
             for (gid, group) in groups:


### PR DESCRIPTION
The system-level accounts removed during our exhaustive pass to destroy
all non-root accounts on the image, are essential to being able to
run APT. Once they've been deleted, it is functionally impossible to
extend a published Pyrex image with additional packages.

Switch to a different strategy: delete all straggler accounts on entry
to the image at runtime.