### PR TITLE
Container commands

### DIFF
--- a/ci/bin/exclude-pyrex-capture-state
+++ b/ci/bin/exclude-pyrex-capture-state
@@ -1,0 +1,1 @@
+pyrex-capture-state

--- a/ci/bin/pyrex-capture-state
+++ b/ci/bin/pyrex-capture-state
@@ -1,0 +1,23 @@
+#! /bin/sh
+#
+# Copyright 2019-2020 Garmin Ltd. or its subsidiaries
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [ "$1" = "podman" ]; then
+    cp --no-preserve=all /proc/1/cmdline "$2"
+else
+    cat /proc/self/cgroup > "$2"
+fi

--- a/ci/test.py
+++ b/ci/test.py
@@ -777,6 +777,44 @@ class PyrexImageType_base(PyrexTest):
                 )
                 self.assertEqual(output, t, msg="Bad $TERM found in container!")
 
+    def test_term_enabled(self):
+        env = os.environ.copy()
+        env["TERM"] = "dumb"
+        output = self.assertPyrexContainerShellPTY(
+            "test -t 1; echo $?",
+            env=env,
+            quiet_init=True,
+        )
+        self.assertEqual(output, "0", msg="Stdout is not a TTY")
+
+        del env["TERM"]
+        output = self.assertPyrexContainerShellPTY(
+            "test -t 1; echo $?",
+            env=env,
+            quiet_init=True,
+        )
+        self.assertEqual(output, "0", msg="Stdout is not a TTY")
+
+    def test_term_disabled(self):
+        env = os.environ.copy()
+        env["TERM"] = "dumb"
+        output = self.assertPyrexContainerShellCommand(
+            "test -t 1; echo $?",
+            env=env,
+            quiet_init=True,
+            capture=True,
+        )
+        self.assertEqual(output, "1", msg="Stdout is a TTY when terminal is not a TTY")
+
+        del env["TERM"]
+        output = self.assertPyrexContainerShellCommand(
+            "test -t 1; echo $?",
+            env=env,
+            quiet_init=True,
+            capture=True,
+        )
+        self.assertEqual(output, "1", msg="Stdout is a TTY when terminal is not a TTY")
+
     def test_tini(self):
         self.assertPyrexContainerCommand("tini --version")
 

--- a/pyrex.ini
+++ b/pyrex.ini
@@ -12,14 +12,22 @@
 # to be specified in the user config file
 confversion = @CONFVERSION@
 
-# A list of globs for commands that should be wrapped by Pyrex. Overrides the
-# command set specified by the container itself when it was captured. Any path
-# starting with a "!" will be excluded from being wrapped by Pyrex and will
-# run directly in the host environment
-#commands =
-#    ${env:PYREX_OEROOT}/bitbake/bin/*
-#    ${env:PYREX_OEROOT}/scripts/*
-#    !${env:PYREX_OEROOT}/scripts/runqemu*
+# A list of additional globs for commands that should be wrapped by Pyrex.
+# Appends to the command set specified by the container itself when it was
+# captured. Any path starting with a "!" will be excluded from being wrapped by
+# Pyrex and will run directly in the host environment. You will often want to
+# root these with an environment variable, remembering to import it with envimport.
+# $PYREX_CONFIG_BIND is usually a good choice here, but you can set and use
+# your own variable if desired. As an example:
+#
+#    ${env:PYREX_CONFIG_BIND}/bin/*
+#    !${env:PYREX_CONFIG_BIND}/bin/exclude_this
+#
+# Note that any command listed here will take precedence over a command with
+# the same name specified by the container, and excludes take precedence over
+# includes. Thus, you can override the containers decision to include or
+# exclude a command by adding it here.
+%commands =
 
 # The Container engine executable (e.g. docker, podman) to use. If the path
 # does not start with a "/", the $PATH environment variable will be searched


### PR DESCRIPTION
Reworks the way that commands specified by the user are wrapped by
Pyrex. Instead of completely replacing the container commands, the user
commands override and extend the container command defintions, taking
precedence over them (i.e. if the user excludes a command it will be
excluded even if the container includes it, and if the user includes it,
it will be included even if the container excludes it).

In order for this to work, the user command shims must be individually
written to execute the full path to the command inside the container,
since we don't know if it will be in $PATH.