### PR TITLE
pyrex.ini: Default to 20.04

### DIFF
--- a/pyrex.ini
+++ b/pyrex.ini
@@ -31,7 +31,7 @@ confversion = @CONFVERSION@
 
 # As a convenience, the name of a Pyrex provided image
 # can be specified here
-%image = ubuntu-18.04-${config:imagetype}
+%image = ubuntu-20.04-${config:imagetype}
 
 # As a convenience, the tag of the Pyrex provided image. Defaults to the
 # Pyrex version.


### PR DESCRIPTION
Defaults to 20.04 since that is the most recent sanity tested Ubuntu
version