### PR TITLE
ci: Fix shell testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,8 @@ jobs:
           export PYTHONPATH=${GITHUB_WORKSPACE}/ci/site/:$PYTHONPATH
           export COVERAGE_PROCESS_START=${GITHUB_WORKSPACE}/.coveragerc
           rm -f .coverage-report.*
-          ${{ matrix.sh }} -c "./ci/test.py -vb PyrexImage_${{ matrix.provider }}_$(echo ${{ matrix.image }} | sed 's/\W/_/g')"
+          export SHELL=${{ matrix.sh }}
+          $SHELL -c "./ci/test.py -vb PyrexImage_${{ matrix.provider }}_$(echo ${{ matrix.image }} | sed 's/\W/_/g')"
 
       - name: Combine coverage
         run: |

--- a/ci/test.py
+++ b/ci/test.py
@@ -240,7 +240,10 @@ class PyrexTest(object):
             init_env=init_env,
         )
         return self.assertSubprocess(
-            ["/bin/bash", cmd_file], pretty_command=command, cwd=cwd, **kwargs
+            [os.environ.get("SHELL", "/bin/bash"), cmd_file],
+            pretty_command=command,
+            cwd=cwd,
+            **kwargs
         )
 
     def assertPyrexContainerShellCommand(self, *args, **kwargs):
@@ -843,14 +846,18 @@ class PyrexImageType_base(PyrexTest):
         self.assertPyrexHostCommand("/bin/true")
         self.assertPyrexHostCommand("/bin/false", returncode=1)
 
+        prefix = []
+        if "zsh" in os.environ.get("SHELL", ""):
+            prefix = ["disable true false"]
+
         true_path = self.assertPyrexHostCommand(
-            "which true", capture=True, quiet_init=True
+            *(prefix + ["which true"]), capture=True, quiet_init=True
         )
         true_link_path = os.readlink(true_path)
         self.assertEqual(os.path.basename(true_link_path), "exec-shim-pyrex")
 
         false_path = self.assertPyrexHostCommand(
-            "which false", capture=True, quiet_init=True
+            *(prefix + ["which false"]), capture=True, quiet_init=True
         )
         false_link_path = os.readlink(false_path)
         self.assertEqual(os.path.basename(false_link_path), "false")


### PR DESCRIPTION
The CI code was always using /bin/bash as the shell interpreter, which
meant that the attempt to test using zsh in the CI jobs was failing.

Special thanks to @QSchulz for discovering the problem