### PR TITLE
Shellcheck scripts (support zsh)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run ShellCheck for host scripts (POSIX)
+        uses: ludeeus/action-shellcheck@1.1.0
+        with:
+          additional_files: 'lint mkconfig pyrex-init-build-env'
+          ignore: 'image'
+        env:
+          SHELLCHECK_OPTS: -s sh -e SC1090 -e SC2181 -e SC3054
+
+      - name: Run ShellCheck for container scripts (bash)
+        uses: ludeeus/action-shellcheck@1.1.0
+        with:
+          scandir: 'image'
+        env:
+          SHELLCHECK_OPTS: -s bash -e SC1090 -e SC2181
+
   check:
     runs-on: ubuntu-20.04
     steps:

--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -16,19 +16,19 @@
 
 set -e
 
-TOP_DIR=$(readlink -f $(dirname $0)/../)
+TOP_DIR=$(readlink -f "$(dirname "$0")/../")
 
-rm -rf $TOP_DIR/poky
-mkdir $TOP_DIR/poky
-wget --no-check-certificate -O $TOP_DIR/poky/poky-2.6.tar.bz2 "https://downloads.yoctoproject.org/releases/yocto/yocto-2.6/poky-thud-20.0.0.tar.bz2"
+rm -rf "$TOP_DIR/poky"
+mkdir "$TOP_DIR/poky"
+wget --no-check-certificate -O "$TOP_DIR/poky/poky-2.6.tar.bz2" "https://downloads.yoctoproject.org/releases/yocto/yocto-2.6/poky-thud-20.0.0.tar.bz2"
 echo 'ef3d4305054282938bfe70dc5a08eba8a701a22b49795b1c2d8ed5aed90d0581 *poky/poky-2.6.tar.bz2' | sha256sum -c
 
-wget --no-check-certificate -O $TOP_DIR/poky/poky-3.1.tar.bz2 "http://downloads.yoctoproject.org/releases/yocto/yocto-3.1/poky-dunfell-23.0.0.tar.bz2"
+wget --no-check-certificate -O "$TOP_DIR/poky/poky-3.1.tar.bz2" "http://downloads.yoctoproject.org/releases/yocto/yocto-3.1/poky-dunfell-23.0.0.tar.bz2"
 echo 'c1f4a486e5f090dbdf50c15a5d22afa6689bd609604b48d63eb0643ad58eb370 *poky/poky-3.1.tar.bz2' | sha256sum -c
 
-mkdir $TOP_DIR/poky/2.6 $TOP_DIR/poky/3.1
+mkdir "$TOP_DIR/poky/2.6" "$TOP_DIR/poky/3.1"
 echo "Extracting..."
-tar -xf $TOP_DIR/poky/poky-2.6.tar.bz2 -C $TOP_DIR/poky/2.6 --strip-components=1
-tar -xf $TOP_DIR/poky/poky-3.1.tar.bz2 -C $TOP_DIR/poky/3.1 --strip-components=1
-ln -s ../../pyrex-init-build-env $TOP_DIR/poky/2.6/
-ln -s ../../pyrex-init-build-env $TOP_DIR/poky/3.1/
+tar -xf "$TOP_DIR/poky/poky-2.6.tar.bz2" -C "$TOP_DIR/poky/2.6" --strip-components=1
+tar -xf "$TOP_DIR/poky/poky-3.1.tar.bz2" -C "$TOP_DIR/poky/3.1" --strip-components=1
+ln -s ../../pyrex-init-build-env "$TOP_DIR/poky/2.6/"
+ln -s ../../pyrex-init-build-env "$TOP_DIR/poky/3.1/"

--- a/image/capture.sh
+++ b/image/capture.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-INIT_PWD=$PWD
-
 # Prevent some variables from being unset so their value can be captured
 unset() {
     for var in "$@"; do
@@ -36,9 +34,6 @@ check_bound() {
              "$PYREXCONFFILE to ensure it is bound into the container."
         exit 1
     fi
-
-    local FILE_DEV="$(stat --format "%D" "$1" )"
-    local ROOT_DEV="$(stat --format "%D" "/")"
 
     if [ "$(findmnt -f -n -o TARGET --target "$1")" == "/" ]; then
         echo "ERROR: $1 not bound in container (File mount target is root)"

--- a/image/capture.sh
+++ b/image/capture.sh
@@ -53,7 +53,7 @@ declare -a PYREX_ARGS=("$@")
 shift $#
 
 # Ensure the init script is bound in the container
-check_bound $PYREX_OEINIT
+check_bound "$PYREX_OEINIT"
 
 # If the bitbake directory argument or environment variable is provided, ensure
 # it is bound in the container
@@ -77,7 +77,7 @@ if [ -n "$OEROOT" ]; then
     check_bound "$OEROOT"
 fi
 
-. $PYREX_OEINIT "${PYREX_ARGS[@]}"
+. "$PYREX_OEINIT" "${PYREX_ARGS[@]}"
 if [ $? -ne 0 ]; then
     exit 1
 fi
@@ -95,9 +95,9 @@ fi
 # Ensure the build directory is bound into the container.
 check_bound "$(pwd)"
 
-check_bound $PYREX_CAPTURE_DEST
+check_bound "$PYREX_CAPTURE_DEST"
 
-cat > $PYREX_CAPTURE_DEST <<HEREDOC
+cat > "$PYREX_CAPTURE_DEST" <<HEREDOC
 {
     "tempdir": "$PWD/pyrex",
     "user" : {

--- a/image/test_startup.sh
+++ b/image/test_startup.sh
@@ -5,4 +5,4 @@ if [ -z "${PYREX_TEST_STARTUP_SCRIPT+isset}" ]; then
 fi
 
 echo "Startup script test"
-exit $PYREX_TEST_STARTUP_SCRIPT
+exit "$PYREX_TEST_STARTUP_SCRIPT"

--- a/lint
+++ b/lint
@@ -19,7 +19,7 @@ if ! which black > /dev/null 2>&1; then
     exit 1
 fi
 
-cd "$(readlink -f "$(dirname "$0")")"
+cd "$(readlink -f "$(dirname "$0")")" || exit 1
 if [ "$1" = "-r" ] || [ "$1" = "--reformat" ]; then
     # shellcheck disable=SC2046
     black $(git ls-files '*.py')

--- a/lint
+++ b/lint
@@ -20,7 +20,7 @@ if ! which black > /dev/null 2>&1; then
 fi
 
 cd "$(readlink -f "$(dirname "$0")")"
-if [ "$1" == "-r" ] || [ "$1" == "--reformat" ]; then
+if [ "$1" = "-r" ] || [ "$1" = "--reformat" ]; then
     # shellcheck disable=SC2046
     black $(git ls-files '*.py')
 else

--- a/lint
+++ b/lint
@@ -19,11 +19,14 @@ if ! which black > /dev/null 2>&1; then
     exit 1
 fi
 
-cd "$(readlink -f $(dirname $0))"
+cd "$(readlink -f "$(dirname "$0")")"
 if [ "$1" == "-r" ] || [ "$1" == "--reformat" ]; then
+    # shellcheck disable=SC2046
     black $(git ls-files '*.py')
 else
+    # shellcheck disable=SC2046
     black --check $(git ls-files '*.py')
 fi
 
+# shellcheck disable=SC2046
 flake8 $(git ls-files '*.py')

--- a/pyrex-init-build-env
+++ b/pyrex-init-build-env
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -n "$BASH_SOURCE" ]; then
+if [ -n "${BASH_SOURCE[*]}" ]; then
 	THIS_SCRIPT=$BASH_SOURCE
 elif [ -n "$ZSH_NAME" ]; then
 	THIS_SCRIPT=$0

--- a/pyrex-init-build-env
+++ b/pyrex-init-build-env
@@ -57,7 +57,7 @@ pyrex_cleanup() {
 
 export PYREXCONFFILE
 
-if [ -n "$PYREXCONFFILE" ] && [ "${PYREXCONFFILE#/}" == "$PYREXCONFFILE" ]; then
+if [ -n "$PYREXCONFFILE" ] && [ "${PYREXCONFFILE#/}" = "$PYREXCONFFILE" ]; then
     PYREXCONFFILE="$(pwd)/$PYREXCONFFILE"
 fi
 

--- a/pyrex-init-build-env
+++ b/pyrex-init-build-env
@@ -30,11 +30,11 @@ fi
 export PYREX_CONFIG_BIND
 
 if [ -z "$PYREX_CONFIG_BIND" ]; then
-	PYREX_CONFIG_BIND="$(readlink -f $(dirname $THIS_SCRIPT))"
+	PYREX_CONFIG_BIND=$(readlink -f "$(dirname "$THIS_SCRIPT")")
 fi
 
 if [ -z "$PYREX_ROOT" ]; then
-	PYREX_ROOT=$(dirname $(readlink -f $THIS_SCRIPT))
+	PYREX_ROOT=$(dirname "$(readlink -f "$THIS_SCRIPT")")
 fi
 
 if [ -z "$PYREX_OEINIT" ]; then
@@ -61,18 +61,18 @@ if [ -n "$PYREXCONFFILE" ] && [ "${PYREXCONFFILE#/}" == "$PYREXCONFFILE" ]; then
     PYREXCONFFILE="$(pwd)/$PYREXCONFFILE"
 fi
 
-$PYREX_ROOT/pyrex.py capture \
+"$PYREX_ROOT/pyrex.py" capture \
 		-a PYREX_OEINIT "$PYREX_OEINIT" \
 		-e PYREXCONFFILE \
 		-e TEMPLATECONF \
 		-- 9 "$@" \
-		9> $PYREX_TEMP_ENV_FILE
+		9> "$PYREX_TEMP_ENV_FILE"
 if [ $? -ne 0 ]; then
 	pyrex_cleanup
 	return 1
 fi
 
-. $PYREX_TEMP_ENV_FILE
+. "$PYREX_TEMP_ENV_FILE"
 if [ $? -ne 0 ]; then
 	pyrex_cleanup
 	return 1


### PR DESCRIPTION
zsh support is broken for scripts to be run on the host. This fixes it and makes sure that we do not introduce further bashism in host scripts by running shellcheck in POSIX mode which most shells should be decently compliant with.

While at it, run shellcheck in bash mode for scripts to be run in container (in `image` directory) since bash only will be used.

This has not been tested.