### PR TITLE
pyrex: define registry where the remote image is stored

### DIFF
--- a/pyrex.ini
+++ b/pyrex.ini
@@ -47,6 +47,10 @@ confversion = @CONFVERSION@
 # repository
 %buildlocal = 0
 
+# The name of the registry where to find the image whose complete name is stored
+# in tag variable. This variable is only used when buildlocal is set to 0.
+%registry = docker.io
+
 # A list of environment variables that should be imported as Pyrex
 # configuration variables in the "env" section, e.g. ${env:HOME}. Note that
 # environment variables accessed in this way must be set or an error will

--- a/pyrex.py
+++ b/pyrex.py
@@ -259,7 +259,11 @@ def build_image(config, build_config):
             build_config["build"]["buildid"] = get_image_id(config, tag)
         except subprocess.CalledProcessError:
             try:
-                engine_args = [engine, "pull", tag]
+                registry = config["config"]["registry"]
+                if registry and not registry.endswith("/"):
+                    registry = registry + "/"
+
+                engine_args = [engine, "pull", registry + tag]
                 subprocess.check_call(engine_args)
 
                 build_config["build"]["buildid"] = get_image_id(config, tag)


### PR DESCRIPTION
When using podman on Fedora 34 (at least), the registry from which to fetch the image is asked. Let's allow a less interactive experience by being able to specify it.

The registry is only used when fetching remotely and not when building locally (passing buildlocal="1" to pyrex.ini).

When using a locally built image, the registry just needs to be unset.

Right now the registry is docker.io as the images are hosted on hub.docker.com.