### PR TITLE
image: Dockerfile: reduce image sizes

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -20,7 +20,7 @@ ARG PYREX_BASE=ubuntu-20.04-oe
 FROM alpine:3.9 AS prebuilt-base
 ENV PYREX_BASE none
 
-RUN apk add --update \
+RUN apk add --no-cache \
     acl-dev \
     alpine-sdk \
     autoconf \
@@ -110,7 +110,7 @@ FROM ubuntu:trusty AS prebuilt-util-linux-14.04
 ENV PYREX_BASE none
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
         build-essential \
         wget
 
@@ -170,7 +170,7 @@ LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 # Install software required to run init scripts.
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
         locales \
         lsb-release \
         ncurses-term \
@@ -201,7 +201,7 @@ LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 # Install software required to run init scripts.
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
         locales \
         lsb-release \
         ncurses-term \
@@ -229,7 +229,7 @@ LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 # Install software required to run init scripts.
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
         locales \
         lsb-release \
         ncurses-term \
@@ -258,7 +258,7 @@ LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 # Install software required to run init scripts.
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
         locales \
         lsb-release \
         ncurses-term \
@@ -287,9 +287,9 @@ LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
 # Add a non-ancient version of git
-    apt-get -y update && apt-get -y install software-properties-common && \
+    apt-get -y update && apt-get -y install --no-install-recommends software-properties-common && \
     add-apt-repository -y ppa:git-core/ppa && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
 # Poky 2.0 build dependencies
     gawk \
     wget \
@@ -366,9 +366,9 @@ LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
 # Add a non-ancient version of git
-    apt-get -y update && apt-get -y install software-properties-common && \
+    apt-get -y update && apt-get -y install --no-install-recommends software-properties-common && \
     add-apt-repository -y ppa:git-core/ppa && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
 # Poky 2.7 build dependencies
     gawk \
     wget \
@@ -439,7 +439,7 @@ LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
 # Poky 2.7 build dependencies
     gawk \
     wget \
@@ -507,7 +507,7 @@ LABEL maintainer="Joshua Watt <Joshua.Watt@garmin.com>"
 
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     ulimit -n 1024 && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
 # Poky 3.1 build dependencies
     gawk \
     wget \
@@ -575,7 +575,7 @@ ENV PYREX_BASE none
 
 RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     sudo dpkg --add-architecture i386 && \
-    apt-get -y update && apt-get -y install \
+    apt-get -y update && apt-get -y install --no-install-recommends \
         wine64 \
         wine32 \
 && rm -rf /var/lib/apt/lists/*
@@ -593,7 +593,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     sudo dpkg --add-architecture i386 && \
     apt -y update && \
     apt -y upgrade apt && \
-    apt -y install \
+    apt -y install --no-install-recommends \
         wine64 \
         wine32 \
 && rm -rf /var/lib/apt/lists/*
@@ -653,7 +653,8 @@ ENV PYREX_BASE none
 # socket. Since the local Icecream daemon (iceccd) is not started when the
 # container starts, the client will not find it and instead connect to the host
 # Icecream daemon (as long as the container is run with --net=host).
-RUN mkdir -p /usr/share/icecc/toolchain && \
+RUN apt-get update -y && apt-get install -y --no-install-recommends file && \
+    mkdir -p /usr/share/icecc/toolchain && \
     cd /usr/share/icecc/toolchain/ && \
     TC_NAME=$(mktemp) && \
     /usr/local/libexec/icecc/icecc-create-env --gcc $(which gcc) $(which g++) 5> $TC_NAME && \


### PR DESCRIPTION
```
$ podman image list
REPOSITORY                             TAG         IMAGE ID      CREATED            SIZE
localhost/14.04-oe                     latest      d104c67516fd  3 minutes ago      591 MB
localhost/16.04-oe                     latest      c8d0485857e4  9 minutes ago      837 MB
localhost/18.04-oe                     latest      79f37896e4c3  18 minutes ago     788 MB
localhost/20.04-oe                     latest      1558b8ec1e28  27 minutes ago     875 MB
docker.io/garminpyrex/ubuntu-14.04-oe  latest      8ea6ca2f1d58  2 months ago       667 MB
docker.io/garminpyrex/ubuntu-16.04-oe  latest      860319693cbd  2 months ago       897 MB
docker.io/garminpyrex/ubuntu-18.04-oe  latest      afd97f4ed060  2 months ago       866 MB
docker.io/garminpyrex/ubuntu-20.04-oe  latest      d4c71c6549f7  2 months ago       904 MB
```
14.04 is 12% smaller, 16.04 7%, 18.04 10% and 20.04 3%.

This was not tested (only built with: `podman build -t 14.04-oe -f image/Dockerfile --build-arg PYREX_BASE=ubuntu-14.04-oe --target pyrex-oe`).