### PR TITLE
pyrex.py: use regexp to find subuid or subgid

### DIFF
--- a/pyrex.py
+++ b/pyrex.py
@@ -316,11 +316,14 @@ def get_engine_info(config):
 
 
 def get_subid_length(filename, name):
+    r = re.compile(r"{}:\d+:(\d+)".format(re.escape(name)))
+
     with open(filename, "r") as f:
         for line in f:
-            (ident, _, id_length) = line.rstrip().split(":")
-            if ident == name:
-                return int(id_length)
+            m = r.match(line)
+            if m is not None:
+                return int(m.group(1))
+
     return 0
 
 


### PR DESCRIPTION
Since what's looked for is explicitly known, let's use a regexp to
specifically find a match and return the appropriate data.

This also helps with hand-crafted /etc/subuid and /etc/subgid where
newlines and comments can be among the expected lines.

Signed-off-by: Quentin Schulz <quentin.schulz@theobroma-systems.com>
Signed-off-by: Quentin Schulz <foss@0leil.net>