### PR TITLE
pyrex.py: Prefix registry for all operations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,6 +111,9 @@ jobs:
         run: |
           ./ci/build_image.py ${{ matrix.image }} --provider=${{ matrix.provider }}
 
+      - name: ${{ matrix.provider }} images
+        run: ${{ matrix.provider }} images
+
       - name: Test image
         run:  |
           export PYTHONPATH=${GITHUB_WORKSPACE}/ci/site/:$PYTHONPATH

--- a/ci/test.py
+++ b/ci/test.py
@@ -125,9 +125,13 @@ class PyrexTest(object):
             config["config"]["image"] = self.test_image
             config["config"]["engine"] = self.provider
             config["config"]["buildlocal"] = "0"
-            config["config"]["pyrextag"] = (
-                os.environ.get(TEST_PREBUILT_TAG_ENV_VAR, "") or "ci-test"
-            )
+            tag = os.environ.get(TEST_PREBUILT_TAG_ENV_VAR, "")
+            if tag:
+                config["config"]["pyrextag"] = tag
+            else:
+                config["config"]["pyrextag"] = "ci-test"
+                config["config"]["registry"] = ""
+
             config["run"]["bind"] += " " + self.build_dir
             config["imagebuild"]["buildcommand"] = "%s --provider=%s %s" % (
                 os.path.join(PYREX_ROOT, "ci", "build_image.py"),

--- a/pyrex.py
+++ b/pyrex.py
@@ -253,17 +253,19 @@ def build_image(config, build_config):
 
         build_config["build"]["buildhash"] = get_build_hash(build_config)
     else:
+        registry = config["config"].get("registry")
+        if registry:
+            if not registry.endswith("/"):
+                registry = registry + "/"
+            tag = registry + tag
+
         try:
             # Try to get the image This will fail if the image doesn't
             # exist locally
             build_config["build"]["buildid"] = get_image_id(config, tag)
         except subprocess.CalledProcessError:
             try:
-                registry = config["config"]["registry"]
-                if registry and not registry.endswith("/"):
-                    registry = registry + "/"
-
-                engine_args = [engine, "pull", registry + tag]
+                engine_args = [engine, "pull", tag]
                 subprocess.check_call(engine_args)
 
                 build_config["build"]["buildid"] = get_image_id(config, tag)


### PR DESCRIPTION
The registry prefix needs to be included for all operations, not just
`docker pull`. Change the way the registry is assigned to be handled
entirely in the pyrex.ini file instead of in the code.