### PR TITLE
Ignore `git` in the scripts directory

### DIFF
--- a/image/capture.sh
+++ b/image/capture.sh
@@ -113,7 +113,8 @@ cat > "$PYREX_CAPTURE_DEST" <<HEREDOC
                 "$OEROOT/scripts/runqemu*",
                 "$OEROOT/scripts/oe-run-native",
                 "$OEROOT/scripts/oe-find-native-sysroot",
-                "$OEROOT/scripts/wic"
+                "$OEROOT/scripts/wic",
+                "$OEROOT/scripts/git"
             ]
         }
     },


### PR DESCRIPTION
Newer versions of OE core include an intercept for git that makes it
ignore pseudo; this command should not be proxied through pyrex so
ignore it.