### PR TITLE
Add git-lfs package

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -218,7 +218,16 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
         python3 \
         sudo \
         curl \
+        apt-transport-https \
     && \
+# Add packagecloud apt source and gpg key and install git-lfs
+#  (Depends on curl and apt-transport-https installed above)
+    install -d -m 0755 -o root -g root /etc/apt/sources.list.d && \
+    curl -sSf 'https://packagecloud.io/install/repositories/github/git-lfs/config_file.list?os=Ubuntu&dist=xenial&source=script' > /etc/apt/sources.list.d/github_git-lfs.list && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL 'https://packagecloud.io/github/git-lfs/gpgkey' | gpg --dearmor > /etc/apt/keyrings/github_git-lfs-archive-keyring.gpg && \
+    apt-get -y update && \
+    apt-get -y install git-lfs && \
 # Clean up apt-cache
     rm -rf /var/lib/apt/lists/* &&\
 # generate utf8 locale
@@ -483,6 +492,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     gawk \
     wget \
     git-core \
+    git-lfs \
     diffstat \
     unzip \
     texinfo \
@@ -553,6 +563,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     gawk \
     wget \
     git \
+    git-lfs \
     diffstat \
     unzip \
     texinfo \
@@ -629,6 +640,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     gawk \
     wget \
     git \
+    git-lfs \
     diffstat \
     unzip \
     texinfo \


### PR DESCRIPTION
Add git-lfs package to each docker image base 16.04 and newer. An Ubuntu package isn't available for 16.04, so it is installed from packagecloud.io.