### PR TITLE
Configure git-lfs for Ubuntu 16.04/18.04

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -228,6 +228,8 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     curl -fsSL 'https://packagecloud.io/github/git-lfs/gpgkey' | gpg --dearmor > /etc/apt/keyrings/github_git-lfs-archive-keyring.gpg && \
     apt-get -y update && \
     apt-get -y install git-lfs && \
+# Configure git lfs
+    git lfs install --system > /dev/null 2>&1 && \
 # Clean up apt-cache
     rm -rf /var/lib/apt/lists/* &&\
 # generate utf8 locale
@@ -540,6 +542,9 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
 # Testing requirements
     wine64 \
     wine32 \
+    && \
+# Configure git lfs
+    git lfs install --system > /dev/null 2>&1 \
 && rm -rf /var/lib/apt/lists/*
 
 # Python modules used by resulttool

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -218,7 +218,16 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
         python3 \
         sudo \
         curl \
+        apt-transport-https \
     && \
+# Add packagecloud apt source and gpg key and install git-lfs
+#  (Depends on curl and apt-transport-https installed above)
+    install -d -m 0755 -o root -g root /etc/apt/sources.list.d && \
+    curl -sSf 'https://packagecloud.io/install/repositories/github/git-lfs/config_file.list?os=Ubuntu&dist=xenial&source=script' > /etc/apt/sources.list.d/github_git-lfs.list && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL 'https://packagecloud.io/github/git-lfs/gpgkey' | gpg --dearmor > /etc/apt/keyrings/github_git-lfs-archive-keyring.gpg && \
+    apt-get -y update && \
+    apt-get -y install git-lfs && \
 # Clean up apt-cache
     rm -rf /var/lib/apt/lists/* &&\
 # generate utf8 locale
@@ -483,6 +492,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     gawk \
     wget \
     git-core \
+    git-lfs \
     diffstat \
     unzip \
     texinfo \
@@ -553,6 +563,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     gawk \
     wget \
     git \
+    git-lfs \
     diffstat \
     unzip \
     texinfo \
@@ -629,6 +640,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     gawk \
     wget \
     git \
+    git-lfs \
     diffstat \
     unzip \
     texinfo \


### PR DESCRIPTION
Ubuntu 20.04+ git-lfs packages have a postinst that runs
'git lfs install --system'; we need to manually do this for 16.04 and
18.04.