### PR TITLE
Fix ubuntu-16.04-oe

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -474,7 +474,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
 && rm -rf /var/lib/apt/lists/*
 
 # Python modules used by resulttool
-RUN python3 -m pip install jinja2 iterfzf
+RUN python3 -m pip install jinja2 iterfzf==0.5.0.20.0
 
 # Copy prebuilt items
 COPY --from=prebuilt-icecream /dist/icecream /


### PR DESCRIPTION
This change fixes ubuntu-16.04-oe, which still has an old version of pip. Use the old version of iterfzf that still has setup.py.

Most tests will not pass anymore because the image will fail to build.