### PR TITLE
Upgrade git-lfs to support local paths

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -1098,6 +1098,22 @@ class PyrexImageType_oe(PyrexImageType_base):
 
         self.assertEqual(oe_topdir, pyrex_topdir)
 
+    @skipIfOS("ubuntu", "14.04")
+    def test_git_lfs_version(self):
+        # Require the version that first supports local paths, so bitbake can
+        # reference a local path with lfs.
+        d = self.assertPyrexContainerCommand(
+            "git lfs version", quiet_init=True, capture=True
+        )
+        # Returns a User-Agent string git-lfs uses,
+        # which is in the format git-lfs/major.minor.patch (platform information)
+        self.assertTrue(d.startswith("git-lfs"))
+        (major, minor, patch) = (
+            int(x) for x in d.split("/")[1].split(" ")[0].split(".")
+        )
+
+        self.assertTrue(major > 2 or (major == 2 and minor >= 10))
+
     def test_env_capture(self):
         if self.pokyver < (4, 0):
             varname = "BB_ENV_EXTRAWHITE"

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -494,7 +494,6 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     gawk \
     wget \
     git-core \
-    git-lfs \
     diffstat \
     unzip \
     texinfo \
@@ -543,9 +542,17 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     wine64 \
     wine32 \
     && \
+# Add packagecloud apt source and gpg key and install git-lfs
+    install -d -m 0755 -o root -g root /etc/apt/sources.list.d && \
+    curl -sSf 'https://packagecloud.io/install/repositories/github/git-lfs/config_file.list?os=Ubuntu&dist=bionic&source=script' > /etc/apt/sources.list.d/github_git-lfs.list && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL 'https://packagecloud.io/github/git-lfs/gpgkey' | gpg --dearmor > /etc/apt/keyrings/github_git-lfs-archive-keyring.gpg && \
+    apt-get -y update && \
+    apt-get -y install git-lfs && \
 # Configure git lfs
-    git lfs install --system > /dev/null 2>&1 \
-&& rm -rf /var/lib/apt/lists/*
+    git lfs install --system > /dev/null 2>&1 && \
+# Clean up apt-cache
+    rm -rf /var/lib/apt/lists/*
 
 # Python modules used by resulttool
 RUN python3 -m pip install iterfzf testtools python-subunit
@@ -568,7 +575,6 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     gawk \
     wget \
     git \
-    git-lfs \
     diffstat \
     unzip \
     texinfo \
@@ -622,8 +628,18 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive && \
     xxd \
 # Testing requirements
     wine64 \
-    wine32 \
-&& rm -rf /var/lib/apt/lists/*
+    wine32 && \
+# Add packagecloud apt source and gpg key and install git-lfs
+    install -d -m 0755 -o root -g root /etc/apt/sources.list.d && \
+    curl -sSf 'https://packagecloud.io/install/repositories/github/git-lfs/config_file.list?os=Ubuntu&dist=focal&source=script' > /etc/apt/sources.list.d/github_git-lfs.list && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL 'https://packagecloud.io/github/git-lfs/gpgkey' | gpg --dearmor > /etc/apt/keyrings/github_git-lfs-archive-keyring.gpg && \
+    apt-get -y update && \
+    apt-get -y install git-lfs && \
+# Configure git lfs
+    git lfs install --system > /dev/null 2>&1 && \
+# Clean up apt-cache
+    rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install iterfzf testtools python-subunit
 


### PR DESCRIPTION
git-lfs support was added, but unfortunately versions before 2.10 don't support local paths.

This can make testing difficult with a bitbake recipe that points to a local path for testing, when that local repository uses LFS. To fix this, we can pull in newer versions of git-lfs like 16.04 had. To make sure git-lfs is new enough, add a test for it. The minimum git-lfs release is v2.10.