### PR TITLE
github actions: Remove podman tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,12 +73,12 @@ jobs:
           - {image: ubuntu-18.04-oegarmin,  provider: docker, sh: bash}
           - {image: ubuntu-20.04-base,      provider: docker, sh: bash}
           - {image: ubuntu-20.04-oe,        provider: docker, sh: bash}
-          - {image: ubuntu-20.04-oe,        provider: podman, sh: bash}
+          #- {image: ubuntu-20.04-oe,        provider: podman, sh: bash}
           - {image: ubuntu-20.04-oetest,    provider: docker, sh: bash}
           - {image: ubuntu-20.04-oegarmin,  provider: docker, sh: bash}
           - {image: ubuntu-22.04-base,      provider: docker, sh: bash}
           - {image: ubuntu-22.04-oe,        provider: docker, sh: bash}
-          - {image: ubuntu-22.04-oe,        provider: podman, sh: bash}
+          #- {image: ubuntu-22.04-oe,        provider: podman, sh: bash}
           - {image: ubuntu-22.04-oegarmin,  provider: docker, sh: bash}
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
20.04 has a problem where podman is not compatible with docker, causing tests to fail