### PR TITLE
Prefix container image with "pyrex-"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,6 @@ jobs:
           if [ "$TAG" = "master" ]; then
             TAG="latest"
           fi
-          docker tag ghcr.io/garmin/${{ matrix.image }}:ci-test ghcr.io/garmin/${{ matrix.image }}:$TAG
-          docker push ghcr.io/garmin/${{ matrix.image }}:$TAG
+          docker tag ghcr.io/garmin/pyrex-${{ matrix.image }}:ci-test ghcr.io/garmin/pyrex-${{ matrix.image }}:$TAG
+          docker push ghcr.io/garmin/pyrex-${{ matrix.image }}:$TAG
         if: ${{ ( github.ref == 'refs/heads/next' || github.ref == 'refs/heads/master' ) && github.event_name == 'push' && matrix.provider == 'docker' }}

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -93,8 +93,8 @@ To make a release of Pyrex:
    For example, the `1.0.0` release would be tagged `v1.0.0`
 4. Tagging the repository will trigger a new CI build. This build will
    automatically push the container images to
-   [dockerhub](https://cloud.docker.com/u/garminpyrex/repository/list) using
-   the same tag that was created for the release. Verify that the
+   [ghcr](https://github.com/orgs/garmin/packages?repo_name=pyrex) using the
+   same tag that was created for the release. Verify that the
    [Release build](https://github.com/garmin/pyrex/actions?query=workflow%3Arelease)
    passes and the container images are pushed. In the unlikely event this
    fails, delete the release, fix the issue, and try again. To manually deploy

--- a/ci/build_image.py
+++ b/ci/build_image.py
@@ -51,7 +51,7 @@ def main():
         provider,
         "build",
         "-t",
-        "ghcr.io/garmin/%s:ci-test" % args.image,
+        "ghcr.io/garmin/pyrex-%s:ci-test" % args.image,
         "-f",
         docker_file,
         "--network=host",

--- a/ci/deploy_docker.py
+++ b/ci/deploy_docker.py
@@ -39,7 +39,7 @@ def deploy_image(top_dir, image, tag):
 
     (_, _, image_type) = image.split("-")
 
-    repo = "garmin/%s" % image
+    repo = "garmin/pyrex-%s" % image
     name = "ghcr.io/%s:%s" % (repo, tag)
 
     print("Deploying %s..." % name)

--- a/pyrex.ini
+++ b/pyrex.ini
@@ -39,7 +39,7 @@ confversion = @CONFVERSION@
 
 # The name of the tag given to the image. If you want to keep around different
 # Pyrex images simultaneously, each should have a unique tag
-%tag = ghcr.io/garmin/${config:image}:${config:pyrextag}
+%tag = ghcr.io/garmin/pyrex-${config:image}:${config:pyrextag}
 
 # If set to 1, the image is built up locally every time the environment is
 # sourced. If set to 0, building the image will be skipped, which means that


### PR DESCRIPTION
The new GHCR repo doesn't have "pyrex" in the namespace, so add a prefix of "pyrex-" to the produced images