### PR TITLE
pyrex.ini: Clarify command documentation

### DIFF
--- a/pyrex.ini
+++ b/pyrex.ini
@@ -16,10 +16,13 @@ confversion = @CONFVERSION@
 # command set specified by the container itself when it was captured. Any path
 # starting with a "!" will be excluded from being wrapped by Pyrex and will
 # run directly in the host environment
+#
+# Remember that in order to reference env: variables here, they must be in
+# envimport
 #commands =
-#    ${env:PYREX_OEROOT}/bitbake/bin/*
-#    ${env:PYREX_OEROOT}/scripts/*
-#    !${env:PYREX_OEROOT}/scripts/runqemu*
+#    ${env:BITBAKEDIR}/bin/*
+#    ${env:OEROOT}/scripts/*
+#    !${env:OEROOT}/scripts/runqemu*
 
 # The Container engine executable (e.g. docker, podman) to use. If the path
 # does not start with a "/", the $PATH environment variable will be searched


### PR DESCRIPTION
The usage of PYREX_OEROOT in config.commands is confusing because it's not actually set anywhere, so change it to OEROOT/BITBAKEDIR and also clarify that these need to be imported to be used