### PR TITLE
gha: Install chrpath on host

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Install packages
         run: |
-          sudo apt install -y diffstat
+          sudo apt install -y \
+            chrpath \
+            diffstat
 
       - name: Install python packages
         run: |


### PR DESCRIPTION
This is require for bitbake to initialize on the host, which is needed in a few tests